### PR TITLE
Max chars for kv name fix

### DIFF
--- a/labs/part03-key-vault/locals.tf
+++ b/labs/part03-key-vault/locals.tf
@@ -5,7 +5,7 @@ locals {
   resource_group_name         = "rg-demo-${local.unique_postfix}"
   virtual_network_name        = "vnet-demo-${local.unique_postfix}"
   network_security_group_name = "nsg-demo-${local.unique_postfix}"
-  key_vault_name              = "kv-demo-${local.unique_postfix}"
+  key_vault_name              = "kv-demo-${format("%.16s", local.unique_postfix)}"
 }
 
 # Caluculate the CIDR for the subnets

--- a/labs/part04-storage-account/locals.tf
+++ b/labs/part04-storage-account/locals.tf
@@ -5,7 +5,7 @@ locals {
   resource_group_name                 = "rg-demo-${local.unique_postfix}"
   virtual_network_name                = "vnet-demo-${local.unique_postfix}"
   network_security_group_name         = "nsg-demo-${local.unique_postfix}"
-  key_vault_name                      = "kv-demo-${local.unique_postfix}"
+  key_vault_name                      = "kv-demo-${format("%.16s", local.unique_postfix)}"
   storage_account_name                = replace("stdemo${local.unique_postfix}", "-", "")
   user_assigned_managed_identity_name = "uami-demo-${local.unique_postfix}"
 }

--- a/labs/part05-virtual-machine/locals.tf
+++ b/labs/part05-virtual-machine/locals.tf
@@ -6,7 +6,7 @@ locals {
   virtual_network_name                = "vnet-demo-${local.unique_postfix}"
   network_security_group_name         = "nsg-demo-${local.unique_postfix}"
   storage_account_name                = replace("stdemo${local.unique_postfix}", "-", "")
-  key_vault_name                      = "kv-demo-${local.unique_postfix}"
+  key_vault_name                      = "kv-demo-${format("%.16s", local.unique_postfix)}"
   user_assigned_managed_identity_name = "uami-demo-${local.unique_postfix}"
   virtual_machine_name                = "vm-demo-${local.unique_postfix}"
   network_interface_name              = "nic-demo-${local.unique_postfix}"


### PR DESCRIPTION
The maximum characters a key vault name can have is 24. Limit using format function. 