### PR TITLE
Removed self-reference to fix circular dependancy

### DIFF
--- a/labs/part04-storage-account/avm.key_vault.tf
+++ b/labs/part04-storage-account/avm.key_vault.tf
@@ -17,7 +17,6 @@ module "key_vault" {
         "wrapKey"
       ]
       key_type     = "RSA"
-      key_vault_id = module.key_vault.resource.id
       name         = "cmk-for-storage-account"
       key_size     = 2048
     }

--- a/labs/part05-virtual-machine/avm.key_vault.tf
+++ b/labs/part05-virtual-machine/avm.key_vault.tf
@@ -17,7 +17,6 @@ module "key_vault" {
         "wrapKey"
       ]
       key_type     = "RSA"
-      key_vault_id = module.key_vault.resource.id
       name         = "cmk-for-storage-account"
       key_size     = 2048
     }


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Fixes a circular dependancy that exists, which prevents deployment once you get to Part 4 and 5 of the tutorial. This gives the following error:
`Error: Cycle: module.key_vault.time_sleep.wait_for_rbac_before_key_operations, module.key_vault.azurerm_key_vault_key.this, module.key_vault.output.resource (expand), module.key_vault.var.keys (expand)`

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
Follow the Part 1 process in the tutorial, then skip to Part 4 and Part 5

## What to Check
Verify that the following are valid
* The terraform plan and deploy execute successfully

## Other Information
<!-- Add any other helpful information that may be needed here. -->