### PR TITLE
Update avm.virtual_machine.tf location in Part 5

### DIFF
--- a/labs/part05-virtual-machine/avm.virtual_machine.tf
+++ b/labs/part05-virtual-machine/avm.virtual_machine.tf
@@ -8,6 +8,7 @@ module "virtual_machine" {
   location                               = var.location
   admin_credential_key_vault_resource_id = module.key_vault.resource.id
   virtualmachine_sku_size                = "Standard_B1s"
+  zone                                   = "1"
 
   managed_identities = {
     system_assigned = true

--- a/labs/part05-virtual-machine/avm.virtual_machine.tf
+++ b/labs/part05-virtual-machine/avm.virtual_machine.tf
@@ -5,6 +5,7 @@ module "virtual_machine" {
   resource_group_name                    = azurerm_resource_group.this.name
   virtualmachine_os_type                 = "linux"
   name                                   = local.virtual_machine_name
+  location                               = var.location
   admin_credential_key_vault_resource_id = module.key_vault.resource.id
   virtualmachine_sku_size                = "Standard_B1s"
 


### PR DESCRIPTION
Module "virtual_machine" is missing required argument "location"

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Adding missing location attribute 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[x] Yes
[ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
  resource_group_name                    = azurerm_resource_group.this.name
  virtualmachine_os_type                 = "linux"
  name                                   = local.virtual_machine_name
  location                               = var.location
  admin_credential_key_vault_resource_id = module.key_vault.resource.id
  virtualmachine_sku_size                = "Standard_B1s"
  zone                                   = "1"
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
terraform init -upgrade
terraform apply -auto-approve
```

## What to Check
Verify that the following are valid
* Part 5 is deployed without error.

## Other Information
<!-- Add any other helpful information that may be needed here. -->